### PR TITLE
remove mention of SkyConnect

### DIFF
--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -9,7 +9,7 @@ guideName: Interfaces
       <ul>
         <li>3 status LEDs.</li>
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
-        <li>2 USB ports to extend the functionality:<ul>          
+        <li>2 USB ports to extend the functionality, such as:<ul>          
           <li>SkyConnect to communicate with Zigbee devices, and in the future with Thread devices.</li>
             <li>Z-Wave stick to communicate with Z-Wave devices.</li>
         </ul></li>

--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -9,8 +9,9 @@ guideName: Interfaces
       <ul>
         <li>3 status LEDs.</li>
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
-        <li>2 USB ports to extend the functionality. <ul>          
-          <li>For example, you could add a Zigbee and a Z-Wave stick to communicate with Zigbee and Z-Wave devices.</li>
+        <li>2 USB ports to extend the functionality:<ul>          
+          <li>SkyConnect to communicate with ZigBee devices, and in the future with Thread devices</li>
+            <li>Z-Wave stick to communicate with Z-Wave devices.</li>
         </ul></li>
       </ul>
   </span> 

--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -9,9 +9,8 @@ guideName: Interfaces
       <ul>
         <li>3 status LEDs.</li>
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
-        <li>2 USB ports to extend the functionality. For example by connecting one of the following devices: <ul>
-          <li>SkyConnect to communicate with Zigbee and Matter-over-Thread devices. <br>Note that Matter-over-Thread support is still experimental.</li>
-          <li>Z-Wave stick to communicate with Z-Wave devices.</li>
+        <li>2 USB ports to extend the functionality. <ul>          
+          <li>For example, you could add a Zigbee and a Z-Wave stick to communicate with Zigbee and Z-Wave devices.</li>
         </ul></li>
       </ul>
   </span> 

--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -11,7 +11,7 @@ guideName: Interfaces
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
         <li>2 USB ports to extend the functionality. For example by connecting one of the following devices: <ul>
           <li>SkyConnect to communicate with Zigbee and Matter-over-Thread devices.</li>
-          <li>Z-Wave controller to communicate with Z-Wave devices.</li>
+          <li>Z-Wave stick to communicate with Z-Wave devices.</li>
         </ul></li>
       </ul>
   </span> 

--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -10,7 +10,7 @@ guideName: Interfaces
         <li>3 status LEDs.</li>
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
         <li>2 USB ports to extend the functionality:<ul>          
-          <li>SkyConnect to communicate with ZigBee devices, and in the future with Thread devices</li>
+          <li>SkyConnect to communicate with Zigbee devices, and in the future with Thread devices.</li>
             <li>Z-Wave stick to communicate with Z-Wave devices.</li>
         </ul></li>
       </ul>

--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -10,7 +10,7 @@ guideName: Interfaces
         <li>3 status LEDs.</li>
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
         <li>2 USB ports to extend the functionality. For example by connecting one of the following devices: <ul>
-          <li>SkyConnect to communicate with Zigbee and Matter-over-Thread devices. Note that Matter-over-Thread support is still experimental.</li>
+          <li>SkyConnect to communicate with Zigbee and Matter-over-Thread devices. <br>Note that Matter-over-Thread support is still experimental.</li>
           <li>Z-Wave stick to communicate with Z-Wave devices.</li>
         </ul></li>
       </ul>

--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -10,7 +10,7 @@ guideName: Interfaces
         <li>3 status LEDs.</li>
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
         <li>2 USB ports to extend the functionality. For example by connecting one of the following devices: <ul>
-          <li>SkyConnect to use Thread and Matter devices.</li>
+          <li>SkyConnect to communicate with Zigbee and Matter-over-Thread devices.</li>
           <li>Z-Wave controller to communicate with Z-Wave devices.</li>
         </ul></li>
       </ul>

--- a/src/documentation/interfaces.html
+++ b/src/documentation/interfaces.html
@@ -10,7 +10,7 @@ guideName: Interfaces
         <li>3 status LEDs.</li>
         <li>MicroSD slot and an HDMI port for recovery and diagnostics.</li>
         <li>2 USB ports to extend the functionality. For example by connecting one of the following devices: <ul>
-          <li>SkyConnect to communicate with Zigbee and Matter-over-Thread devices.</li>
+          <li>SkyConnect to communicate with Zigbee and Matter-over-Thread devices. Note that Matter-over-Thread support is still experimental.</li>
           <li>Z-Wave stick to communicate with Z-Wave devices.</li>
         </ul></li>
       </ul>


### PR DESCRIPTION
- Remove SkyConnect as option, since multiprotocol and Matter-over-Thread support are still experimental, and targeted at advanced users
- Replace term Z-Wave controller by Z-Wave stick to implement feedback.