### PR TITLE
LEDs: remove info that LEDs cannot yet be disabled

### DIFF
--- a/src/documentation/green-leds.html
+++ b/src/documentation/green-leds.html
@@ -33,7 +33,7 @@ guideName: Home Assistant Green LEDs
   <p>The yellow system health LED blinks in a heartbeat pattern if the Home Assistant operating system is running.</p>
   <p></p>
   <a class="anchor" href="#disabling-the-leds"><h2 class="anchor">Disabling the LEDs</h2></a>
-  <p>It is not yet possible to disable the LEDs. This feature is planned for the next update; HAOS version 11.0.</p>
+  <p>This feature requires HAOS version 11.0.</p>
   <p>If the LEDs seem to bright for your environment, you can disable them.</p>
   <ol>
     <li>Go to <a class="my" href="https://my.home-assistant.io/redirect/hardware/" target="_blank"><b>Settings</b> > <b>System</b> > <b>Hardware</b></a> and select <b>Configure</b> > <b>Configure hardware settings</b>.</li>


### PR DESCRIPTION
- feature was added with HAOS 11.0 and is now available