### PR TITLE
Reset procedure: connect device to Internet before startup

### DIFF
--- a/src/guides/guides.11tydata.yaml
+++ b/src/guides/guides.11tydata.yaml
@@ -17,7 +17,7 @@ procedureFactoryReset:
       image: green_reset_insert_sd.webp
       content: |
         <ul>
-          <li>Insert the SD card with the Home Assistant Green OS installer.</li>
+          <li>Insert the SD card with the Home Assistant Green OS installer.</li><li>Make sure the Home Assistant Green is connected to the Internet.</li>
         </ul>
     - title: Powering up the system
       image: green_reset_power-up_after_sd-insert.webp

--- a/src/guides/guides.11tydata.yaml
+++ b/src/guides/guides.11tydata.yaml
@@ -17,7 +17,8 @@ procedureFactoryReset:
       image: green_reset_insert_sd.webp
       content: |
         <ul>
-          <li>Insert the SD card with the Home Assistant Green OS installer.</li><li>Make sure the Home Assistant Green is connected to the Internet.</li>
+          <li>Insert the SD card with the Home Assistant Green OS installer.</li>
+          <li>Make sure the Home Assistant Green is connected to the Internet.</li>
         </ul>
     - title: Powering up the system
       image: green_reset_power-up_after_sd-insert.webp


### PR DESCRIPTION
Reset procedure
- add missing step instructing to connect the Green to the Internet before starting up the device